### PR TITLE
refactor: add hidden-count flag in filter-menu-item molecule

### DIFF
--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.component.tsx
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.component.tsx
@@ -17,21 +17,22 @@ export const FilterMenuItem: FC<IFilterMenuItem> = ({
   isSearched,
   customClass,
   customId,
+  hiddenCount,
   setIsApplied
 }) => {
   const displayOutput = useMemo(() => {
     if (isApplied) return <IconItem icon={SmallClose} size={17} />
-    if (!hasTotal) return <Fragment />
+    if (!hasTotal || hiddenCount) return <Fragment />
     return <output>{formatNumber(total)}</output>
-  }, [isApplied, total, hasTotal])
+  }, [total, isApplied, hasTotal, hiddenCount])
 
   const disabled = useMemo(() => {
-    return isSearched || isApplied ? false : !total
-  }, [isApplied, isSearched, total])
+    return isSearched || isApplied || hiddenCount ? false : !total
+  }, [total, isApplied, isSearched, hiddenCount])
 
   const className = useMemo(() => {
-    return isApplied ? styles.selected : isSearched ? styles.isSearched : !total && styles.disabled
-  }, [isApplied, isSearched, total])
+    return isApplied ? styles.selected : isSearched ? styles.isSearched : hiddenCount ? '' : !total && styles.disabled
+  }, [total, isApplied, isSearched, hiddenCount])
 
   const handleClick = useCallback(() => {
     setIsApplied({ id, field, isApplied, multiple })
@@ -54,5 +55,6 @@ export const FilterMenuItem: FC<IFilterMenuItem> = ({
 }
 
 FilterMenuItem.defaultProps = {
-  isSearched: false
+  isSearched: false,
+  hiddenCount: false
 }

--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.interface.ts
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.interface.ts
@@ -30,6 +30,10 @@ export interface IFilterMenuItem extends IFilterValue {
    */
   customId?: string
   /**
+   * This is a flag if the vacant is internal
+   */
+  hiddenCount?: boolean
+  /**
    * This function change if the item is isSelected
    */
   setIsApplied: (filter: ISetIsApplied) => Promise<void> | void


### PR DESCRIPTION
# Description

- Add hiddenCount flag in FilterMenuItem molecule.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
