### PR TITLE
Feat/26063 clear filters btn visible

### DIFF
--- a/src/components/UI/atoms/MainButton/MainButton.component.tsx
+++ b/src/components/UI/atoms/MainButton/MainButton.component.tsx
@@ -16,6 +16,7 @@ const Component: React.FC<IMainButton> = ({
   isMobile,
   className,
   title,
+  disabled,
   onClick
 }) => {
   const stylesValue: CSSProperties = useMemo(() => toCSSVariables(buttonStyles), [buttonStyles])
@@ -40,13 +41,14 @@ const Component: React.FC<IMainButton> = ({
 
   return (
     <button
-      className={`${styles.MainButtonComponent} ${className}`}
+      className={`${styles.MainButtonComponent} ${className} ${disabled ? styles.disabled : ''}`}
       type={buttonType}
       style={stylesValue}
       onClick={onClick}
       data-button-size={buttonSize}
       data-is-mobile={isMobile}
       title={title}
+      disabled={disabled}
     >
       {renderContent()}
     </button>

--- a/src/components/UI/atoms/MainButton/MainButton.interface.ts
+++ b/src/components/UI/atoms/MainButton/MainButton.interface.ts
@@ -59,4 +59,8 @@ export interface IMainButton {
    * This te title attribute for the button tag
    */
   title?: string
+  /**
+   * It specifies that the button should be disabled.
+   */
+  disabled?: boolean
 }

--- a/src/components/UI/atoms/MainButton/MainButton.modules.scss
+++ b/src/components/UI/atoms/MainButton/MainButton.modules.scss
@@ -100,3 +100,8 @@
     @include fullButton;
   }
 }
+
+.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.module.scss
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.module.scss
@@ -60,6 +60,10 @@
   }
 }
 
+.magneto-ui-filter-item:hover {
+  background-color: v.$disabled-color-gray2;
+}
+
 .skeleton {
   display: inline-block;
   width: 230px;

--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.module.scss
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.module.scss
@@ -14,6 +14,7 @@
   border-radius: 50px;
   box-sizing: border-box;
   margin: 5px 0;
+  transition: all ease-in-out 0.3s;
   cursor: pointer;
 
   @media (max-width: v.$screen-md) {

--- a/src/components/UI/organism/FilterHeader/FilterHeader.component.tsx
+++ b/src/components/UI/organism/FilterHeader/FilterHeader.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, useMemo } from 'react'
+import React, { FC, useMemo } from 'react'
 import { Broom } from '@constants/icons.constants'
 import { MainButton } from '@components/UI/atoms'
 import { Switch } from '@components/UI/atoms/Switch'
@@ -19,16 +19,18 @@ export const FilterHeader: FC<IFilterHeader> = ({
       title: buttonText,
       iconProps: { icon: Broom, size: 18 },
       className: styles['magneto-ui-filter-header_btn'],
+      disabled: !totalApplied,
       onClick: () => clearFilters()
     }
-  }, [buttonText, clearFilters])
+  }, [buttonText, totalApplied, clearFilters])
 
   const displayBtnClear = useMemo(() => {
-    if (!totalApplied) return <Fragment />
     return (
       <div className={styles['magneto-ui-filter-header_clean']}>
         <MainButton {...mainBtnProps} />
-        {totalApplied && <span>{`(${totalApplied})`}</span>}
+        {typeof totalApplied === 'number' && (
+          <span className={!totalApplied ? styles.disabled : ''}>{`(${totalApplied})`}</span>
+        )}
       </div>
     )
   }, [totalApplied, mainBtnProps])

--- a/src/components/UI/organism/FilterHeader/FilterHeader.modules.scss
+++ b/src/components/UI/organism/FilterHeader/FilterHeader.modules.scss
@@ -84,3 +84,7 @@ $filter-font-color: #282835;
     color: $filter-font-color;
   }
 }
+
+.disabled {
+  opacity: 0.4;
+}


### PR DESCRIPTION
# Description

- Show an disabled button to clear filters when isn't filters aplayed.
- Put hover in FilterMenuItem molecule.

Fixes # (issue)

- https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/26062
- https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/26063/


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
