### PR TITLE
fix: validate if the type of the filter is type range and send the fr…

### DIFF
--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.component.tsx
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.component.tsx
@@ -12,13 +12,15 @@ export const FilterMenuItem: FC<IFilterMenuItem> = ({
   field,
   multiple,
   loading,
+  type,
   isApplied,
   hasTotal,
   isSearched,
   customClass,
   customId,
   hiddenCount,
-  setIsApplied
+  setIsApplied,
+  ...props
 }) => {
   const displayOutput = useMemo(() => {
     if (isApplied) return <IconItem icon={SmallClose} size={17} />
@@ -35,8 +37,9 @@ export const FilterMenuItem: FC<IFilterMenuItem> = ({
   }, [total, isApplied, isSearched, hiddenCount])
 
   const handleClick = useCallback(() => {
-    setIsApplied({ id, field, isApplied, multiple })
-  }, [setIsApplied, id, field, isApplied, multiple])
+    const customId = type === 'RANGE' ? { id, from: props.from, to: props.to } : id
+    setIsApplied({ id: customId, field, isApplied, multiple })
+  }, [setIsApplied, id, field, isApplied, multiple, type, props.from, props.to])
 
   if (loading) return <div className={styles.skeleton} />
 

--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.component.tsx
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.component.tsx
@@ -37,7 +37,7 @@ export const FilterMenuItem: FC<IFilterMenuItem> = ({
   }, [total, isApplied, isSearched, hiddenCount])
 
   const handleClick = useCallback(() => {
-    const customId = type === 'RANGE' ? { id, from: props.from, to: props.to } : id
+    const customId = type === 'RANGE' ? { id: id as string, from: props.from as string, to: props.to as string } : id
     setIsApplied({ id: customId, field, isApplied, multiple })
   }, [setIsApplied, id, field, isApplied, multiple, type, props.from, props.to])
 

--- a/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.interface.ts
+++ b/src/components/UI/molecules/FilterMenuItem/FilterMenuItem.interface.ts
@@ -14,6 +14,10 @@ export interface IFilterMenuItem extends IFilterValue {
    */
   loading: boolean
   /**
+   * This type shows how send the id in the setIsApplied function
+   */
+  type?: string | null
+  /**
    * This flag indicate if the item render the total of vacancies
    */
   hasTotal?: boolean

--- a/src/components/UI/organism/FilterCard/FilterCard.component.tsx
+++ b/src/components/UI/organism/FilterCard/FilterCard.component.tsx
@@ -62,7 +62,7 @@ export const FilterCard: FC<IFilterCard> = ({
       )}
       <div className={styles['magneto-ui-filter-card_options']}>
         {options.map((opt, key) => {
-          const optProps = { ...props, ...opt, hasTotal, setIsApplied }
+          const optProps = { ...props, ...opt, hasTotal, setIsApplied, type: props.type }
           return <FilterMenuItem key={`${key}-${opt.label}`} {...optProps} />
         })}
       </div>

--- a/src/components/UI/organism/FilterCardOnSearch/FilterCardOnSearch.interface.ts
+++ b/src/components/UI/organism/FilterCardOnSearch/FilterCardOnSearch.interface.ts
@@ -16,7 +16,7 @@ export interface ISetIsAppliedProps {
   /**
    * This is the ai of the filter to apply or de-apply
    */
-  id: string | number
+  id: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
   /**
    * This is the flag that indicate if the filter is applied
    */

--- a/src/components/UI/organism/FilterCardOnSearch/FilterCardOnSearch.interface.ts
+++ b/src/components/UI/organism/FilterCardOnSearch/FilterCardOnSearch.interface.ts
@@ -16,7 +16,7 @@ export interface ISetIsAppliedProps {
   /**
    * This is the ai of the filter to apply or de-apply
    */
-  id: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
+  id: string | number | { id: string; from: string | number; to: string | number }
   /**
    * This is the flag that indicate if the filter is applied
    */

--- a/src/components/UI/template/SideFilter/SideFilter.interface.ts
+++ b/src/components/UI/template/SideFilter/SideFilter.interface.ts
@@ -127,16 +127,16 @@ export interface IFilterValue {
 
 export interface ISetIsApplied {
   field: string
-  id: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
+  id: string | number | { id: string; from: string | number; to: string | number }
   isApplied: boolean
   multiple: boolean
 }
 
 export interface IUnApplyWithChild {
   child: IFilter
-  parentId: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
+  parentId: string | number | { id: string; from: string | number; to: string | number }
   parentField: string
-  newParentId?: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
+  newParentId?: string | number | { id: string; from: string | number; to: string | number }
 }
 export interface ISearchRenderTypeOption {
   id: string | number

--- a/src/components/UI/template/SideFilter/SideFilter.interface.ts
+++ b/src/components/UI/template/SideFilter/SideFilter.interface.ts
@@ -127,16 +127,16 @@ export interface IFilterValue {
 
 export interface ISetIsApplied {
   field: string
-  id: string | number
+  id: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
   isApplied: boolean
   multiple: boolean
 }
 
 export interface IUnApplyWithChild {
   child: IFilter
-  parentId: string | number
+  parentId: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
   parentField: string
-  newParentId?: string | number
+  newParentId?: string | number | { id?: string | number; from?: string | number | null; to?: string | number | null }
 }
 export interface ISearchRenderTypeOption {
   id: string | number


### PR DESCRIPTION

# Description

- Validate if the type of the filter is 'range' and send the 'from' and 'to' values.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
