### PR TITLE
feat: add optional offer-company-name props in job-header atom

### DIFF
--- a/src/components/UI/atoms/JobHeader/JobHeader.component.tsx
+++ b/src/components/UI/atoms/JobHeader/JobHeader.component.tsx
@@ -1,12 +1,24 @@
-import React from 'react'
+import React, { Fragment, useMemo } from 'react'
 import { IJobHeader } from './JobHeader.interface'
 import styles from './JobHeader.module.scss'
 
-const Component: React.FC<IJobHeader> = ({ offerTitle, offerCompanyName, isHidden }) => {
+const Component: React.FC<IJobHeader> = ({ offerTitle, offerCompanyName, offerCompanyLink, isHidden }) => {
+  const showCompanyName = useMemo(() => {
+    if (isHidden || !offerCompanyName) return <Fragment />
+    if (offerCompanyLink) {
+      return (
+        <a className={styles['magneto-ui-job-header__link']} href={offerCompanyLink} title={offerCompanyName}>
+          {offerCompanyName}
+        </a>
+      )
+    }
+    return <h3 className={styles['magneto-ui-job-header__subtitle']}>{offerCompanyName}</h3>
+  }, [isHidden, offerCompanyLink, offerCompanyName])
+
   return (
     <div className={styles['magneto-ui-job-header']}>
       <h2 className={styles['magneto-ui-job-header__title']}>{offerTitle}</h2>
-      {!isHidden && <h3 className={styles['magneto-ui-job-header__subtitle']}>{offerCompanyName}</h3>}
+      {showCompanyName}
     </div>
   )
 }

--- a/src/components/UI/atoms/JobHeader/JobHeader.interface.ts
+++ b/src/components/UI/atoms/JobHeader/JobHeader.interface.ts
@@ -10,6 +10,10 @@ export interface IJobHeader {
    */
   offerCompanyName?: string
   /**
+   * The optional company url to see his vacancies.
+   */
+  offerCompanyLink?: string
+  /**
    * Specifies whether the job header is hidden or visible.
    * (Optional property)
    */

--- a/src/components/UI/atoms/JobHeader/JobHeader.module.scss
+++ b/src/components/UI/atoms/JobHeader/JobHeader.module.scss
@@ -15,12 +15,27 @@
     color: v.$text-color-blue;
   }
 
-  &__subtitle {
+  &__subtitle,
+  &__link {
     margin: 0;
     font-size: 13px;
     font-style: normal;
     font-weight: 400;
     line-height: normal;
     color: v.$colors-magneto-neutral;
+  }
+
+  &__link {
+    padding: 1px 10px;
+    margin-left: -10px;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: all ease-in-out 0.3s;
+    cursor: pointer;
+
+    &:hover {
+      color: v.$colors-magneto-neutral;
+      background-color: v.$disabled-color-gray;
+    }
   }
 }


### PR DESCRIPTION
# Description

- Add offerCompanyLink prop in JobHeader atom.

Fixes # (issue)

- https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/27384


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
