### PR TITLE
feat: refactor breadcrumb to use it without js by seo

### DIFF
--- a/src/components/UI/atoms/Breadcrumb/Breadcrumb.component.tsx
+++ b/src/components/UI/atoms/Breadcrumb/Breadcrumb.component.tsx
@@ -1,53 +1,38 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { IBreadcrumb } from './Breadcrumb.interface'
 import styles from './Breadcrumb.modules.scss'
 
 const Component: React.FC<IBreadcrumb> = ({
   breadcrumbText,
   breadcrumbCustomText,
-  baseUrl,
   queryParams,
   haveRedirect = true,
-  detailTitle = ''
+  detailTitle = '',
+  breadCrumbFromServer,
+  urlFromServer
 }) => {
   const breadcrumbs = breadcrumbCustomText ? breadcrumbCustomText : breadcrumbText || ''
   const breadcrumbSplitText = breadcrumbs?.split('/')
   const lastIndexBC = breadcrumbSplitText?.length - 1
-  const [urls, setUrls] = useState<string[]>([])
   const haveDetailTitle = detailTitle !== ''
   const detailTileStyle = detailTitle ? styles['no-transform'] : ''
+  const regexBase4 = /[0-9a-f]{8} [0-9a-f]{4} [0-9a-f]{4} [0-9a-f]{4} [0-9a-f]{12}/g
 
-  useEffect(() => {
-    const url = new URL(breadcrumbText, baseUrl)
-    const pathArray = url.pathname?.split('/').filter((el) => el !== '')
-
-    const newUrls = []
-
-    for (let i = 0; i < pathArray?.length; i++) {
-      const urlPath = pathArray
-        ?.slice(0, i + 1)
-        .join('/')
-        .replace(/%20|\s+/g, '-')
-      const newUrl = new URL(urlPath, baseUrl)
-      newUrls.push(newUrl.href)
-    }
-
-    setUrls(newUrls)
-  }, [breadcrumbText, baseUrl])
-
+  // This removes the base64 from the vacancy breadcrumbs
+  const title = breadcrumbSplitText[lastIndexBC].replace(/-/g, ' ').replace(regexBase4, '')
   const breadCrumbsRender = useMemo(() => {
     return haveRedirect ? (
       <>
-        {urls.map(
+        {breadCrumbFromServer?.map(
           (href, i) =>
-            urls.length - 1 !== i && (
-              <a href={`${href}${queryParams ? queryParams : ''}`} key={i}>
-                <p>/ {breadcrumbSplitText[i + 1]}</p>
+            breadCrumbFromServer.length - 1 !== i && (
+              <a href={`${urlFromServer?.[i]}${queryParams ? queryParams : ''}`} key={i}>
+                <p>/ {href}</p>
               </a>
             )
         )}
         <p className={`${styles['magneto-ui-bc-active']} ${detailTileStyle}`}>
-          / {haveDetailTitle ? detailTitle : breadcrumbSplitText[lastIndexBC]}
+          / {haveDetailTitle ? detailTitle : title}
         </p>
       </>
     ) : (
@@ -59,7 +44,18 @@ const Component: React.FC<IBreadcrumb> = ({
         ))}
       </>
     )
-  }, [breadcrumbSplitText, haveRedirect, lastIndexBC, urls, queryParams, detailTitle, haveDetailTitle, detailTileStyle])
+  }, [
+    haveRedirect,
+    breadCrumbFromServer,
+    detailTileStyle,
+    haveDetailTitle,
+    detailTitle,
+    title,
+    breadcrumbSplitText,
+    urlFromServer,
+    queryParams,
+    lastIndexBC
+  ])
 
   return <div className={styles.breadcrumbComponent}>{breadCrumbsRender}</div>
 }

--- a/src/components/UI/atoms/Breadcrumb/Breadcrumb.interface.ts
+++ b/src/components/UI/atoms/Breadcrumb/Breadcrumb.interface.ts
@@ -23,4 +23,14 @@ export interface IBreadcrumb {
    * this text replace the last position in the bredcrumbs text if it exists
    */
   detailTitle?: string | null
+
+  /**
+   * This field is used to load the breadcrumbs text from the server [SEO]
+   */
+  breadCrumbFromServer?: string[]
+
+  /**
+   * This field is used to load breadcrumb URLs from the server [SEO]
+   */
+  urlFromServer?: string[]
 }

--- a/src/constants/stories/headers.constants.ts
+++ b/src/constants/stories/headers.constants.ts
@@ -47,11 +47,15 @@ export const brands: IBrands[] = [
 ]
 
 export const breadcrumbProps: IBreadcrumb = {
-  breadcrumbText: '/empleos/busqueda/sugeridos',
+  breadcrumbText: '/empleos/validador-de-negocios-de-vivienda-9a322b78-249e-4932-970e-7853eea97bc6',
   baseUrl: 'http://localhost:8080',
-  breadcrumbCustomText: '/profile/search/suggested',
   queryParams: '?utm=google&utm_source=facebook&utm_medium=cueros',
-  haveRedirect: true
+  haveRedirect: true,
+  breadCrumbFromServer: ['empleos', 'validador de negocios de vivienda 9a322b78 249e 4932 970e 7853eea97bc6'],
+  urlFromServer: [
+    'http://localhost:8060/co/empleos',
+    'http://localhost:8060/co/validador-de-negocios-de-vivienda-9a322b78-249e-4932-970e-7853eea97bc6'
+  ]
 }
 
 export const menuItems1440: IMenuItems[] = [


### PR DESCRIPTION
# Description

https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/29882/

The Breadcrumbs molecule was refactored to be able to use it without Javascript, it will generate the url list of the breadcrumbs even if the JS is disabled, this is to improve SEO

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Test Configuration**:

- SDK: Jest
- Software version: 26
- Toolchain: super-test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
