### PR TITLE
Added prop to hide footer and frequent search

### DIFF
--- a/src/components/UI/molecules/FrequentSearch/FrequentSearch.component.tsx
+++ b/src/components/UI/molecules/FrequentSearch/FrequentSearch.component.tsx
@@ -1,10 +1,16 @@
-import React, { useMemo, useState } from 'react'
+import React, { Fragment, useMemo, useState } from 'react'
 import { IFrequentSearch } from './FrequentSearch.interface'
 import styles from './FrequentSearch.module.scss'
 import { SearchItem } from '@components/UI/atoms'
 import { useMediaQuery } from '../../../hooks/useMediaQuery/index'
 
-const Component: React.FC<IFrequentSearch> = ({ searchHeading, searchList, showLess, showMore }) => {
+const Component: React.FC<IFrequentSearch> = ({
+  searchHeading,
+  searchList,
+  showLess,
+  showMore,
+  showFrequentSearch
+}) => {
   const [showFullList, setShowFullList] = useState(true)
 
   const searchListDinamyc = useMemo(() => {
@@ -17,33 +23,39 @@ const Component: React.FC<IFrequentSearch> = ({ searchHeading, searchList, showL
   const searchListResponsive = useMediaQuery(searchList, { md: searchListDinamyc })
 
   return (
-    <div className={styles['magneto-ui-frequent-search']}>
-      <h2 className={styles['magneto-ui-frequent-search__heading']}>{searchHeading}</h2>
-      <div className={styles['magneto-ui-frequent-search__items']}>
-        {searchListResponsive.map(({ ...props }, i) => (
-          <SearchItem key={i} {...props} />
-        ))}
-      </div>
-      <div className={styles['magneto-ui-frequent-search__buttons-container']}>
-        {showFullList ? (
-          <button
-            className={styles['magneto-ui-frequent-search__buttons-container--btn']}
-            onClick={() => setShowFullList(false)}
-            title={showMore}
-          >
-            {showMore} ({searchList.length})
-          </button>
-        ) : (
-          <button
-            className={styles['magneto-ui-frequent-search__buttons-container--btn']}
-            onClick={() => setShowFullList(true)}
-            title={showLess}
-          >
-            {showLess}
-          </button>
-        )}
-      </div>
-    </div>
+    <>
+      {showFrequentSearch !== false ? (
+        <div className={styles['magneto-ui-frequent-search']}>
+          <h2 className={styles['magneto-ui-frequent-search__heading']}>{searchHeading}</h2>
+          <div className={styles['magneto-ui-frequent-search__items']}>
+            {searchListResponsive.map(({ ...props }, i) => (
+              <SearchItem key={i} {...props} />
+            ))}
+          </div>
+          <div className={styles['magneto-ui-frequent-search__buttons-container']}>
+            {showFullList ? (
+              <button
+                className={styles['magneto-ui-frequent-search__buttons-container--btn']}
+                onClick={() => setShowFullList(false)}
+                title={showMore}
+              >
+                {showMore} ({searchList.length})
+              </button>
+            ) : (
+              <button
+                className={styles['magneto-ui-frequent-search__buttons-container--btn']}
+                onClick={() => setShowFullList(true)}
+                title={showLess}
+              >
+                {showLess}
+              </button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <Fragment />
+      )}
+    </>
   )
 }
 

--- a/src/components/UI/molecules/FrequentSearch/FrequentSearch.interface.ts
+++ b/src/components/UI/molecules/FrequentSearch/FrequentSearch.interface.ts
@@ -18,4 +18,6 @@ export interface IFrequentSearch {
    * This text should be 'Show more' text
    */
   showMore: string
+
+  showFrequentSearch?: boolean
 }

--- a/src/components/UI/molecules/FrequentSearch/FrequentSearch.stories.tsx
+++ b/src/components/UI/molecules/FrequentSearch/FrequentSearch.stories.tsx
@@ -9,7 +9,8 @@ const meta: Meta<typeof FrequentSearch> = {
     searchHeading: 'Empleos mas frecuentes',
     searchList,
     showLess: 'Ver menos -',
-    showMore: 'Ver mas'
+    showMore: 'Ver mas',
+    showFrequentSearch: true
   }
 }
 

--- a/src/components/UI/template/Footer/Footer.component.tsx
+++ b/src/components/UI/template/Footer/Footer.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { LogoComponent } from '@components/UI/atoms'
 import { LogoMagneto } from '@constants/icons.constants'
 import { classMUI } from '@constants/stories'
@@ -9,23 +9,35 @@ import { FooterMenuLinks } from '@components/UI/organism/FooterMenuLinks'
 import { IFooter } from './Footer.interface'
 import { MagnetoResolution } from '@components/UI/molecules/MagnetoResolution'
 
-const Footer: React.FC<IFooter> = ({ followText, magnetoResolutionProps, rightsReservedProps, menuFooterLink }) => {
+const Footer: React.FC<IFooter> = ({
+  followText,
+  magnetoResolutionProps,
+  rightsReservedProps,
+  menuFooterLink,
+  showFooter
+}) => {
   return (
-    <footer className={`${style[`${classMUI}-footer`]}`}>
-      <div className={`${style[`${classMUI}-footer__row1`]}`}>
-        <div className={`${style[`${classMUI}-footer__row1--column1`]}`}>
-          <LogoComponent alt="magneto logo" logo={LogoMagneto} />
-          <MagnetoSocialMedia followText={followText} />
-          <RightsReservedText {...rightsReservedProps} />
-        </div>
-        <div className={`${style[`${classMUI}-footer__row1--column2`]}`}>
-          <FooterMenuLinks {...menuFooterLink} />
-        </div>
-      </div>
-      <div className={`${style[`${classMUI}-footer__resolution`]}`}>
-        <MagnetoResolution {...magnetoResolutionProps} />
-      </div>
-    </footer>
+    <>
+      {showFooter !== false ? (
+        <footer className={`${style[`${classMUI}-footer`]}`}>
+          <div className={`${style[`${classMUI}-footer__row1`]}`}>
+            <div className={`${style[`${classMUI}-footer__row1--column1`]}`}>
+              <LogoComponent alt="magneto logo" logo={LogoMagneto} />
+              <MagnetoSocialMedia followText={followText} />
+              <RightsReservedText {...rightsReservedProps} />
+            </div>
+            <div className={`${style[`${classMUI}-footer__row1--column2`]}`}>
+              <FooterMenuLinks {...menuFooterLink} />
+            </div>
+          </div>
+          <div className={`${style[`${classMUI}-footer__resolution`]}`}>
+            <MagnetoResolution {...magnetoResolutionProps} />
+          </div>
+        </footer>
+      ) : (
+        <Fragment />
+      )}
+    </>
   )
 }
 

--- a/src/components/UI/template/Footer/Footer.interface.ts
+++ b/src/components/UI/template/Footer/Footer.interface.ts
@@ -7,4 +7,5 @@ export interface IFooter {
   magnetoResolutionProps: IMagnetoResolution
   rightsReservedProps: IRightsReservedText
   menuFooterLink: IFooterMenuLinks
+  showFooter?: boolean
 }

--- a/src/components/UI/template/Footer/Footer.stories.tsx
+++ b/src/components/UI/template/Footer/Footer.stories.tsx
@@ -10,7 +10,8 @@ const meta: Meta<typeof Footer> = {
     followText: 'Siguenos',
     magnetoResolutionProps: MagnetoResolutionProps,
     rightsReservedProps: RightsReservedProps,
-    menuFooterLink: listMenuText
+    menuFooterLink: listMenuText,
+    showFooter: undefined
   }
 }
 


### PR DESCRIPTION
# Description

This change was made to be able to use the JobsPage in the companies/slug/jobs routes, to avoid errors with the H1 and when you deactivate the JS
https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/29871

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Test Configuration**:

- SDK: Jest
- Software version: 26
- Toolchain: super-test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
