### PR TITLE
refactor: allow slug has multiple values

### DIFF
--- a/src/components/UI/molecules/HeaderTabs/HeaderTabs.component.tsx
+++ b/src/components/UI/molecules/HeaderTabs/HeaderTabs.component.tsx
@@ -8,7 +8,14 @@ const Component: React.FC<IHeaderTabs> = ({ headerTabList = [], urlParam = '', a
     <div className={styles.HeaderTabsComponent} data-add-divider={addDivider}>
       {headerTabList.map(({ ...headerTabProps }, index: number) => (
         <React.Fragment key={index}>
-          <HeaderTab {...headerTabProps} isActive={urlParam === headerTabProps.slug ? true : false} />
+          <HeaderTab
+            {...headerTabProps}
+            isActive={
+              Array.isArray(headerTabProps.slug)
+                ? headerTabProps.slug.includes(urlParam)
+                : urlParam === headerTabProps.slug
+            }
+          />
         </React.Fragment>
       ))}
     </div>

--- a/src/components/UI/molecules/HeaderTabs/HeaderTabs.interface.ts
+++ b/src/components/UI/molecules/HeaderTabs/HeaderTabs.interface.ts
@@ -1,7 +1,10 @@
 import { IHeaderTab } from '../../atoms/'
 
 export interface HeaderTabItem extends Omit<IHeaderTab, 'isActive'> {
-  slug?: string
+  /**
+   * the slug match with the urlParam to active the HeaderTab.
+   */
+  slug?: string | Array<string>
 }
 
 export interface IHeaderTabs {

--- a/src/components/UI/molecules/ListMenuIcons/ListMenuIcons.component.tsx
+++ b/src/components/UI/molecules/ListMenuIcons/ListMenuIcons.component.tsx
@@ -21,7 +21,11 @@ const Component: React.FC<IListMenuIcons> = ({ urlParam, menuItems, menuItems144
             <p>{title ? title : null}</p>
             {items.map(({ slug, icon, ...props }, i: number) => (
               <Fragment key={i}>
-                <MenuIcon icon={icon} isActive={urlParam === slug ? true : false} {...props} />
+                <MenuIcon
+                  icon={icon}
+                  isActive={Array.isArray(slug) ? slug.includes(urlParam) : urlParam === slug}
+                  {...props}
+                />
               </Fragment>
             ))}
           </div>

--- a/src/components/UI/molecules/MenuIcon/MenuIcon.interface.ts
+++ b/src/components/UI/molecules/MenuIcon/MenuIcon.interface.ts
@@ -28,9 +28,9 @@ export interface IMenuIcon {
    */
   url?: string
   /**
-   * Here is the url
+   * Here is the url could be a list.
    */
-  slug?: string
+  slug?: string | Array<string>
   /**
    * You must specify the type between link or button
    */

--- a/src/constants/stories/headers.constants.ts
+++ b/src/constants/stories/headers.constants.ts
@@ -5,7 +5,6 @@ import {
   Add,
   AllJobs,
   ArchiveTick,
-  ClipboardClose,
   DocumentText,
   HambergerMenu,
   Home2,
@@ -102,22 +101,11 @@ export const MenuItems: IMenuItems[] = [
         text: 'Guardados',
         slug: 'guardados',
         url: ''
-      }
-    ]
-  },
-  {
-    title: 'Procesos',
-    items: [
-      {
-        icon: TaskSquare,
-        text: 'Activos',
-        slug: '',
-        url: ''
       },
       {
-        icon: ClipboardClose,
-        text: 'Inactivos',
-        slug: '',
+        icon: TaskSquare,
+        text: 'En proceso',
+        slug: ['', ''],
         url: ''
       }
     ]
@@ -267,20 +255,10 @@ export const ProcessTabsProps: IHeaderTabs = {
   urlParam: 'sugeridos',
   headerTabList: [
     {
-      tabType: 'tabTitle',
-      url: '#',
-      tabText: 'Procesos:'
-    },
-    {
       tabType: 'tabOption',
       url: '#',
-      tabText: 'Activos',
-      slug: 'procesos-activos'
-    },
-    {
-      tabType: 'tabOption',
-      url: '#',
-      tabText: 'Inactivos'
+      tabText: 'En proceso',
+      slug: ['procesos-activos', 'procesos-inactivos']
     }
   ],
   addDivider: true


### PR DESCRIPTION
# Description

This PR its a refactor in the slug param to HeaderTabs and MenuIcon component. The slug param will accept and array of strings to have multiple slugs, that was the most simple solution to resolve [31352](https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/31352). Another possible solution is using RegExp but can add unnecessary complex in component use.

Azure [31352](https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/31352)

Figma [prototype](https://www.figma.com/file/9TsFDAum7yPaWjnnTm2UOx/Ofertas-de-empleo?type=design&node-id=4375-100714&mode=dev)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

In storybook there is a demo to aproach the prototype solution.

**Test Configuration**:

- SDK: Jest
- Software version: 26
- Toolchain: super-test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
