### PR TITLE
feat: add optional props to share popover

### DIFF
--- a/src/components/UI/molecules/SharePopover/SharePopover.interface.ts
+++ b/src/components/UI/molecules/SharePopover/SharePopover.interface.ts
@@ -29,4 +29,10 @@ export interface ISharePopover extends IShareButton {
   classNameContent?: string
 
   classNameButton?: string
+
+  /**
+   * These props will apply in the popover content,
+   * (in the button component to be more specific).
+   */
+  btnProps?: JSX.IntrinsicElements['button']
 }

--- a/src/components/UI/molecules/SharePopover/SharePopover.tsx
+++ b/src/components/UI/molecules/SharePopover/SharePopover.tsx
@@ -5,7 +5,13 @@ import { Share } from '../../../../constants/icons.constants'
 import { ShareIcons } from '../../../../constants/vacancies.constants'
 import { ISharePopover } from './SharePopover.interface'
 
-const Component: React.FC<ISharePopover> = ({ shareLinks, classNameContent = '', classNameButton = '', ...rest }) => {
+const Component: React.FC<ISharePopover> = ({
+  shareLinks,
+  btnProps = {},
+  classNameContent = '',
+  classNameButton = '',
+  ...rest
+}) => {
   const [show, setShow] = useState(false)
 
   return (
@@ -44,7 +50,11 @@ const Component: React.FC<ISharePopover> = ({ shareLinks, classNameContent = '',
         </ul>
       }
     >
-      <button className={[style['popover__btn'], classNameButton].join(' ')} onClick={() => setShow((show) => !show)}>
+      <button
+        {...btnProps}
+        className={[style['popover__btn'], classNameButton].join(' ')}
+        onClick={() => setShow((show) => !show)}
+      >
         <IconItem size={20} icon={Share} />
       </button>
     </Popover>


### PR DESCRIPTION
# Description

* add optional prop to SharePopover to add any prop allowed in button component.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:

- SDK: Jest
- Software version: 26
- Toolchain: super-test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
