### PR TITLE
fix: add andle scroll in text-area atom

### DIFF
--- a/src/components/UI/atoms/TextArea/TextArea.component.tsx
+++ b/src/components/UI/atoms/TextArea/TextArea.component.tsx
@@ -17,10 +17,14 @@ const TextArea: React.FC<ITextArea> = ({
 
   const haveValueOrFocus = onFocus || value.length > 0
 
-  const handleScroll: UIEventHandler<HTMLTextAreaElement> = useCallback((event) => {
-    const { scrollTop } = event.target as HTMLTextAreaElement
-    setShowPlaceholder(scrollTop === 0)
-  }, [])
+  const handleScroll: UIEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      const { scrollTop } = event.target as HTMLTextAreaElement
+      if (!!scrollTop !== showPlaceholder) return
+      setShowPlaceholder(scrollTop === 0)
+    },
+    [showPlaceholder]
+  )
 
   return (
     <div className={styles[`${classMUI}-text-area`]}>

--- a/src/components/UI/atoms/TextArea/TextArea.component.tsx
+++ b/src/components/UI/atoms/TextArea/TextArea.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { UIEventHandler, useCallback, useState } from 'react'
 import { ITextArea } from './TextArea.interface'
 import { classMUI } from '@constants/stories'
 import styles from './TextArea.module.scss'
@@ -13,21 +13,30 @@ const TextArea: React.FC<ITextArea> = ({
   disabled = false
 }) => {
   const [onFocus, setOnFocus] = useState(false)
+  const [showPlaceholder, setShowPlaceholder] = useState(true)
+
   const haveValueOrFocus = onFocus || value.length > 0
+
+  const handleScroll: UIEventHandler<HTMLTextAreaElement> = useCallback((event) => {
+    const { scrollTop } = event.target as HTMLTextAreaElement
+    setShowPlaceholder(scrollTop === 0)
+  }, [])
 
   return (
     <div className={styles[`${classMUI}-text-area`]}>
       <div className={styles[`${classMUI}-text-area--container`]}>
-        <label
-          htmlFor={name}
-          style={{
-            top: haveValueOrFocus ? '5px' : '10px',
-            fontSize: haveValueOrFocus ? '12px' : '14px'
-          }}
-          className={styles[`${classMUI}-text-area--container__label`]}
-        >
-          {placeholder}
-        </label>
+        {showPlaceholder && (
+          <label
+            htmlFor={name}
+            style={{
+              top: haveValueOrFocus ? '5px' : '10px',
+              fontSize: haveValueOrFocus ? '12px' : '14px'
+            }}
+            className={styles[`${classMUI}-text-area--container__label`]}
+          >
+            {placeholder}
+          </label>
+        )}
         <textarea
           disabled={disabled}
           className={styles[`${classMUI}-text-area--container__text-area`]}
@@ -36,6 +45,7 @@ const TextArea: React.FC<ITextArea> = ({
           onChange={onChange}
           onFocus={() => setOnFocus(true)}
           onBlur={() => setOnFocus(false)}
+          onScroll={handleScroll}
           id={name}
           rows={rows}
         />


### PR DESCRIPTION
# Description

Doesn´t show the label with the placeholder if the textarea has scroll applied.

Fixes # (issue)

- https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/32454

## Type of change


- [x ] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
