### PR TITLE
fix: back text and popover behavior

### DIFF
--- a/src/components/UI/molecules/Actions/Actions.component.tsx
+++ b/src/components/UI/molecules/Actions/Actions.component.tsx
@@ -14,7 +14,8 @@ const Component: React.FC<IActions> = ({
   saveButtonProps,
   shareButtonProps,
   copyButtonProps,
-  offerCompanyName
+  offerCompanyName,
+  backText
 }) => {
   const [component, setComponent] = useState<React.ReactElement>()
 
@@ -43,6 +44,7 @@ const Component: React.FC<IActions> = ({
               offerCompanyName={offerCompanyName}
               shareButtonProps={copyButtonProps}
               ActionsHeader={ActionsHeader}
+              backText={backText}
               onBack={handleBack}
             />
           )
@@ -69,7 +71,8 @@ const ShareLinksAction: React.FC<IShareLinksActions> = ({
   onBack,
   shareButtonProps: { shareLinks = [], ...shareProps },
   ActionsHeader,
-  offerCompanyName
+  offerCompanyName,
+  backText
 }) => {
   return (
     <div className={styles['magneto-ui-actions']}>
@@ -95,7 +98,7 @@ const ShareLinksAction: React.FC<IShareLinksActions> = ({
         <button className={styles['magneto-ui-actions__button']} onClick={() => onBack()}>
           <IconItem size={20} icon={ArrowLeft2} />
         </button>
-        Volver
+        {backText}
       </div>
     </div>
   )

--- a/src/components/UI/molecules/Actions/Actions.interface.ts
+++ b/src/components/UI/molecules/Actions/Actions.interface.ts
@@ -49,6 +49,10 @@ export interface IActions {
    * company name.
    */
   offerCompanyName?: string
+  /**
+   * just a text to inform about back action.
+   */
+  backText?: string
 }
 
 export interface IShareLinksActions {
@@ -64,4 +68,8 @@ export interface IShareLinksActions {
    * company name.
    */
   offerCompanyName?: string
+  /**
+   * just a text to inform about back action.
+   */
+  backText?: string
 }

--- a/src/components/UI/molecules/Actions/Actions.stories.tsx
+++ b/src/components/UI/molecules/Actions/Actions.stories.tsx
@@ -39,6 +39,8 @@ export const Default: Story = {
       content: 'Compartir',
       title: 'Compartir'
     },
-    externalButtonChild: <MainButton buttonText="Aplicar" />
+    externalButtonChild: <MainButton buttonText="Aplicar" />,
+    backText: 'Volver',
+    offerCompanyName: 'Grupo Exito'
   }
 }

--- a/src/components/UI/molecules/SharePopover/SharePopover.module.scss
+++ b/src/components/UI/molecules/SharePopover/SharePopover.module.scss
@@ -19,6 +19,12 @@
     }
   }
 
+  &--hidden {
+    > :first-child {
+      z-index: -1;
+    }
+  }
+
   &__btn {
     background: transparent;
     border: none;

--- a/src/components/UI/molecules/SharePopover/SharePopover.tsx
+++ b/src/components/UI/molecules/SharePopover/SharePopover.tsx
@@ -16,7 +16,7 @@ const Component: React.FC<ISharePopover> = ({
 
   return (
     <Popover
-      className={style['popover']}
+      className={[style['popover'], !show ? style['popover--hidden'] : ''].join(' ')}
       positionX="right"
       positionY="bottom"
       show={show}
@@ -44,7 +44,6 @@ const Component: React.FC<ISharePopover> = ({
               {...rest}
               onCopySuccess={() => {
                 rest.onCopySuccess()
-                setShow(false)
               }}
             />
           </li>
@@ -55,6 +54,7 @@ const Component: React.FC<ISharePopover> = ({
         {...btnProps}
         className={[style['popover__btn'], classNameButton].join(' ')}
         onClick={() => setShow((show) => !show)}
+        onBlur={() => setShow(false)}
       >
         <IconItem size={20} icon={Share} />
       </button>

--- a/src/components/UI/page/JobsPage/JobsPage.stories.tsx
+++ b/src/components/UI/page/JobsPage/JobsPage.stories.tsx
@@ -188,7 +188,9 @@ const mobileJobDetailsDrawer = {
         onCopySuccess: () => console.log('Success'),
         shareLinks
       },
-      externalButtonChild: <MainButton buttonText="Aplicar" />
+      externalButtonChild: <MainButton buttonText="Aplicar" />,
+      backText: 'Volver',
+      offerCompanyName: 'Grupo Exito'
     },
     onClose: true
   },


### PR DESCRIPTION
# Description

* When the button in the share popover lost the focus it close automatically.
* change popover content z-index while it close to avoid over position in the share popover button.
* add new param "backText" for text to back action.

Azure [32580](https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/32580) [32581](https://dev.azure.com/TalentaGeneral/TTL/_workitems/edit/32581)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- SDK: Jest
- Software version: 26
- Toolchain: super-test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
