### PR TITLE
fix: add className to link and share components

### DIFF
--- a/src/components/Domain/Jobs/JobDetails/children/JobDetailsAction/JobDetailsAction.component.tsx
+++ b/src/components/Domain/Jobs/JobDetails/children/JobDetailsAction/JobDetailsAction.component.tsx
@@ -42,7 +42,7 @@ const SharePopover: React.FC<IJobDetailsAction.SharePopover> = ({
     classNameButton={cx('action', `action--${variant}`, { 'action--rounded': rounded }, rest.classNameButton)}
     iconPopoverSize={iconPopoverSize ?? 18}
     iconPopover={icon && iconJobDetailsAction[icon]}
-    classNameContent={rest.classNameContent}
+    classNameContent={cx(rest.classNameContent)}
   />
 )
 


### PR DESCRIPTION
# Description

This feat add classname to link a popover component into job details action

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I have performed a self-review of my own code
